### PR TITLE
Fixed Compatibility issue with DataAttributes

### DIFF
--- a/Neutral Animals/src/main/java/com/smushytaco/neutral_animals/mixins/DamageAttributes.java
+++ b/Neutral Animals/src/main/java/com/smushytaco/neutral_animals/mixins/DamageAttributes.java
@@ -4,20 +4,16 @@ import net.minecraft.entity.attribute.AttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.passive.*;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(LivingEntity.class)
 public abstract class DamageAttributes {
-    @Shadow
-    @Final
-    private AttributeContainer attributes;
-    @Inject(method = "getAttributes", at = @At("HEAD"))
+    @Inject(method = "getAttributes", at = @At("RETURN"))
     private void hookGetAttributes(CallbackInfoReturnable<AttributeContainer> cir) {
         LivingEntity livingEntity = (LivingEntity) (Object) this;
+		AttributeContainer attributes = cir.getReturnValue();
         if (attributes.hasAttribute(EntityAttributes.GENERIC_ATTACK_DAMAGE) || !(livingEntity instanceof ChickenEntity) && !(livingEntity instanceof CowEntity) && !(livingEntity instanceof PigEntity) && !(livingEntity instanceof RabbitEntity) && !(livingEntity instanceof SheepEntity)) return;
         ((AttributeContainerAccess) attributes).getCustom().putIfAbsent(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE, (it) -> {}));
     }


### PR DESCRIPTION
Fixes Issue #2 

DataAttributes overrides LivingEntity#getAttributes and returns a custom AttributeContainer instance, making LivingEntity#attributes useless.

The Mixin DataAttributes uses has a priority set such that it is applied before other Mixins, meaning that by setting this inject to RETURN instead of HEAD, you can safely get the DataAttributes container and make the alterations needed for Neutral-Animals.

That said, this is not the ideal way to add EntityAttributes#ATTACK_DAMAGE to the chicken, cow, pig, rabbit and sheep entities. Instead, you should consider adding this attribute through the entity's respective static DefaultAttributeContainer methods. You already have a Mixin for each of these entities so it should be no problem. An example of this can be seen with JamiesWhiteShirt reach-entity-attributes [here](https://github.com/JamiesWhiteShirt/reach-entity-attributes/blob/1.18/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/LivingEntityMixin.java) (instead of LivingEntity#createLivingAttributes it would be CowEntity#createCowAttributes etc.).