### PR TITLE
Actually fixed it this time

### DIFF
--- a/Neutral Animals/src/main/java/com/smushytaco/neutral_animals/mixins/DamageAttributes.java
+++ b/Neutral Animals/src/main/java/com/smushytaco/neutral_animals/mixins/DamageAttributes.java
@@ -1,20 +1,31 @@
 package com.smushytaco.neutral_animals.mixins;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.AttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributes;
-import net.minecraft.entity.passive.*;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.entity.passive.ChickenEntity;
+import net.minecraft.entity.passive.CowEntity;
+import net.minecraft.entity.passive.PigEntity;
+import net.minecraft.entity.passive.RabbitEntity;
+import net.minecraft.entity.passive.SheepEntity;
+import net.minecraft.world.World;
+
 @Mixin(LivingEntity.class)
 public abstract class DamageAttributes {
-    @Inject(method = "getAttributes", at = @At("RETURN"))
-    private void hookGetAttributes(CallbackInfoReturnable<AttributeContainer> cir) {
-        LivingEntity livingEntity = (LivingEntity) (Object) this;
-		AttributeContainer attributes = cir.getReturnValue();
-        if (attributes.hasAttribute(EntityAttributes.GENERIC_ATTACK_DAMAGE) || !(livingEntity instanceof ChickenEntity) && !(livingEntity instanceof CowEntity) && !(livingEntity instanceof PigEntity) && !(livingEntity instanceof RabbitEntity) && !(livingEntity instanceof SheepEntity)) return;
-        ((AttributeContainerAccess) attributes).getCustom().putIfAbsent(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE, (it) -> {}));
-    }
+	
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void init(EntityType<? extends LivingEntity> entityType, World world, CallbackInfo info) {
+		LivingEntity livingEntity = (LivingEntity)(Object)this;
+		AttributeContainer container = livingEntity.getAttributes();
+		
+		if(!container.hasAttribute(EntityAttributes.GENERIC_ATTACK_DAMAGE) && (livingEntity instanceof ChickenEntity || livingEntity instanceof CowEntity || livingEntity instanceof PigEntity || livingEntity instanceof RabbitEntity || livingEntity instanceof SheepEntity)) {
+			((AttributeContainerAccess)container).getCustom().putIfAbsent(EntityAttributes.GENERIC_ATTACK_DAMAGE, new EntityAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE, (it) -> {}));
+		}
+	}
 }


### PR DESCRIPTION
Rather than inserting the damage attribute the first time LivingEntity#getAttributes is called, we insert it when the entity is first constructed. This is a safer and faster solution: the logic to determine whether we insert attack damage or not is performed only once when the entity is constructed, instead of every time we want to get the entity's attributes. More importantly, this should _actually_ fix the compatibility issue between DataAttributes and Neutral Animals (sorry about that!).

Additionally, this implementation gives you more opportunities to be specific or abstract about what entities get to be a neutral mob further down the line by giving you native access to the entity's EntityType; lots of potential for greater control/configurability in the future if needed/wanted.